### PR TITLE
Set Nav Options on Settings Screen Header

### DIFF
--- a/js/WalletSettings/SettingsComponent.js
+++ b/js/WalletSettings/SettingsComponent.js
@@ -41,25 +41,13 @@ class SettingsComponent extends PureComponent {
       refreshing: false,
       modalVisible: false,
     };
-
     this.flatListLayout = null
-
-   this.initTheme();
-
-    // let ostUserId = this.props.ostUserId;
-    // let delegate = this.props.ostWalletUIWorkflowCallback;
-
-    let ostUserId = this.props.route.params.ostUserId;
-    let delegate = this.props.route.params.ostWalletUIWorkflowCallback;
-
-    /// If using react-navigation.
-    // let navigation = this.props.navigation;
-    // if ( navigation && navigation.getParam ) {
-    //   ostUserId = ostUserId || navigation.getParam("ostUserId");
-    //   delegate  = delegate || navigation.getParam("ostWalletUIWorkflowCallback");
-    // }
-
-    this.controller = new WalletSettingsController(ostUserId, delegate);
+    this.initTheme();
+    const { ostUserId, ostWalletUIWorkflowCallback, navOptions } = this.props.route.params
+    if (navOptions) {
+      this.props.navigation.setOptions(navOptions)
+    }
+    this.controller = new WalletSettingsController(ostUserId, ostWalletUIWorkflowCallback);
   }
 
   initTheme(){


### PR DESCRIPTION
If a `navOptions` route param is passed in, set the navigation options on the settings screen.

This change is used to pass a custom back button and screen title to the wallet settings component.